### PR TITLE
Add config w32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ install-sh
 ltmain.sh
 build/
 !config.m4
+!config.w32
 
 # Test specific Ignores
 tests/*.diff

--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,15 @@
+/* $Id$ */
+
+ARG_ENABLE("eos_datastructures", "Additional Datastructures for PHP7", "no");
+
+if (PHP_EOS_DATASTRUCTURES != "no") {
+    configure_module_dirname = configure_module_dirname + "\\src";
+    EXTENSION("eos_datastructures", " \
+    eos_datastructures.c \
+    enum.c \
+    struct.c \
+	");
+
+	AC_DEFINE("HAVE_EOS_DATASTRUCTURES", 1);
+	PHP_INSTALL_HEADERS("ext/eos_datastructures", "php_eos_datastructures_api.h");
+}

--- a/config.w32
+++ b/config.w32
@@ -8,8 +8,8 @@ if (PHP_EOS_DATASTRUCTURES != "no") {
     eos_datastructures.c \
     enum.c \
     struct.c \
-	");
+    ");
 
-	AC_DEFINE("HAVE_EOS_DATASTRUCTURES", 1);
-	PHP_INSTALL_HEADERS("ext/eos_datastructures", "php_eos_datastructures_api.h");
+    AC_DEFINE("HAVE_EOS_DATASTRUCTURES", 1);
+    PHP_INSTALL_HEADERS("ext/eos_datastructures", "php_eos_datastructures_api.h");
 }


### PR DESCRIPTION
This makes it possible to compile php_eos_datastructures.dll for PHP7.0 on Windows (VC14)