### PR TITLE
Fix: changed php_eos_datastructures_check_value to actually compare a…

### DIFF
--- a/src/enum.c
+++ b/src/enum.c
@@ -75,6 +75,10 @@ PHP_EOS_DATASTRUCTURES_API zend_bool php_eos_datastructures_check_value(zend_cla
 	zend_bool return_value = 0;
 
 	ZEND_HASH_FOREACH_VAL(&ce->constants_table, val) {
+        	if (Z_TYPE_P(val) == IS_PTR) {
+            		val = (zval *) Z_PTR_P(val);
+        	}
+
 		if(Z_LVAL_P(val) == value) {
 			return_value = 1;
 			break;


### PR DESCRIPTION
… long against value instead of a ptr which always failed

Hi @auroraeosrose,

please have a look at this pull request, that as far as I can see, fixed the issues with the check value function, that always failed with an error when used for example in pecl-cairo:

TypeError: Value 1 provided is not a const in enum Cairo\Antialias

Cheers,
Michael
